### PR TITLE
upgrade xml dependency to 4.2

### DIFF
--- a/lib/src/util/discover_helper.dart
+++ b/lib/src/util/discover_helper.dart
@@ -113,7 +113,7 @@ class DiscoverHelper {
     //print(definition);
     var config = ClientConfig();
     try {
-      var document = xml.parse(definition);
+      var document = xml.XmlDocument.parse(definition);
       for (var node in document.children) {
         if (node is xml.XmlElement && node.name.local == 'clientConfig') {
           var versionAttributes =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   intl: ^0.16.1
   crypto: ^2.1.4
   basic_utils: ^2.5.3
-  xml: ^3.6.1
+  xml: ">=4.2.0 <5.0.0"
 
 
 dev_dependencies:


### PR DESCRIPTION
There seem to be no big incompatibilities, I only fixed a deprecation warning.
I guess it would even be possible to use a `">=3.6.1 <5.0.0"` if this is preferable, and stick to using the (deprecated) `xml.parse` method.