### PR TITLE
smtp: properly handle exceptions which occour while sending smtp commands.

### DIFF
--- a/lib/smtp/smtp_client.dart
+++ b/lib/smtp/smtp_client.dart
@@ -224,12 +224,18 @@ class SmtpClient {
     }
     var response = SmtpResponse(responseTexts);
     if (_currentCommand != null) {
-      var commandText = _currentCommand.nextCommand(response);
-      if (commandText != null) {
-        write(commandText);
-      } else if (_currentCommand.isCommandDone(response)) {
-        _currentCommand.completer.complete(response);
-        //_log("Done with command ${_currentCommand.command}");
+      try {
+        var commandText = _currentCommand.nextCommand(response);
+        if (commandText != null) {
+          write(commandText);
+        } else if (_currentCommand.isCommandDone(response)) {
+          _currentCommand.completer.complete(response);
+          //_log("Done with command ${_currentCommand.command}");
+          _currentCommand = null;
+        }
+      } catch (exception, stackTrace) {
+        _log('Error proceeding to nextCommand. $exception');
+        _currentCommand?.completer?.completeError(exception, stackTrace);
         _currentCommand = null;
       }
     }

--- a/test/mock_socket.dart
+++ b/test/mock_socket.dart
@@ -279,7 +279,8 @@ class MockSocket implements Socket {
     var text = obj.toString();
     var data = _encoder.convert(text);
     //print('socket: [$text]');
-    _other._subscription.handleData(data);
+    // make the socket asynchronous.
+    Timer.run(() => _other._subscription.handleData(data));
   }
 
   @override

--- a/test/smtp/smtp_client_test.dart
+++ b/test/smtp/smtp_client_test.dart
@@ -1,3 +1,4 @@
+import 'package:enough_mail/src/smtp/smtp_command.dart';
 import 'package:test/test.dart';
 import 'dart:io';
 import 'package:event_bus/event_bus.dart';
@@ -116,6 +117,23 @@ void main() {
     expect(response.type, SmtpResponseType.success);
     expect(response.code, 221);
   });
+
+  test('SmtpClient with exception', () async {
+    final command = DummySmtpCommand('example');
+    try {
+      final response = await client.sendCommand(DummySmtpCommand('example'));
+      fail('sendCommand should throw. (but got: $response)');
+    } catch (e, stackTrace) {
+      expect(e, isA<DummySmtpCommand>());
+    }
+  });
+
+class DummySmtpCommand extends SmtpCommand {
+  DummySmtpCommand(String command) : super(command);
+  @override
+  String nextCommand(SmtpResponse response) {
+    throw this;
+  }
 }
 
 void _log(String text) {


### PR DESCRIPTION
Fixes #80 

I had to make the `MockSocket` (a bit more) asynchronous, so the exception is not throw directly to the test methods.
