### PR TITLE
Allow malformed UTF-8 text

### DIFF
--- a/lib/src/imap/imap_response_line.dart
+++ b/lib/src/imap/imap_response_line.dart
@@ -4,7 +4,7 @@ import 'dart:typed_data';
 import 'parser_helper.dart';
 
 class ImapResponseLine {
-  static const Utf8Decoder _decoder = Utf8Decoder();
+  static const Utf8Decoder _decoder = Utf8Decoder(allowMalformed: true);
   String rawLine;
   String line;
   int literal;

--- a/lib/src/util/uint8_list_reader.dart
+++ b/lib/src/util/uint8_list_reader.dart
@@ -5,7 +5,7 @@ import 'package:enough_mail/src/util/ascii_runes.dart';
 
 /// Combines several Uin8Lists to read from them sequentially
 class Uint8ListReader {
-  static const Utf8Decoder _utf8decoder = Utf8Decoder();
+  static const Utf8Decoder _utf8decoder = Utf8Decoder(allowMalformed: true);
   Uint8List _data = Uint8List(0);
 
   void add(Uint8List list) {


### PR DESCRIPTION
This is kind of a temporary fix for #102 .
Previously, you were not able to catch the error (I actually don't know why).
Now fetching alone works now. Parsing (`MailCodec.decodeAnyText`) still fails. But you can check the charset & encoding and skip the text decoding for a specific mail which is better than the whole process crashed.