### PR TITLE
SMTP | Send mail should not include "Bcc:" header

### DIFF
--- a/lib/src/smtp/commands/smtp_sendmail_command.dart
+++ b/lib/src/smtp/commands/smtp_sendmail_command.dart
@@ -53,10 +53,14 @@ class SmtpSendMailCommand extends SmtpCommand {
         break;
       case SmtpSendCommandSequence.data:
         _currentStep = SmtpSendCommandSequence.done;
+
+        // Build the message but strip the bcc header
+        var data = _message.renderMessage().replaceAll(
+          RegExp('^Bcc:.*\r\n', multiLine: true), ''
+        );
+
         // \r\n.\r\n is the data stop sequence, so 'pad' this sequence in the message data
-        var data = _message.renderMessage()
-          ..replaceAll('\r\n.\r\n', '\r\n..\r\n');
-        return data + '\r\n.';
+        return data.replaceAll('\r\n.\r\n', '\r\n..\r\n') + '\r\n.';
       default:
         return null;
     }


### PR DESCRIPTION
I was wondering why I saw the Bcc recipients. Usually the "RCPT TO" is send but the header is not. 
That's what I included here. Don't think it should intercept with the Mail Loader parts since it's in "smtp_sendmail_command".