### PR TITLE
Add ESEARCH and ESORT extensions

### DIFF
--- a/lib/enough_mail.dart
+++ b/lib/enough_mail.dart
@@ -10,6 +10,7 @@ export 'imap/message_sequence.dart';
 export 'imap/metadata.dart';
 export 'imap/qresync.dart';
 export 'imap/resource_limit.dart';
+export 'imap/return_option.dart';
 
 export 'pop/pop_client.dart';
 export 'pop/pop_events.dart';

--- a/lib/imap/imap_client.dart
+++ b/lib/imap/imap_client.dart
@@ -1328,10 +1328,33 @@ class ImapClient extends ClientBase {
   /// [sortCriteria] the criteria used for sorting the results like 'ARRIVAL' or 'SUBJECT'
   /// [searchCriteria] the criteria like 'UNSEEN' or 'RECENT'
   /// [charset] the charset used for the searching criteria
+  /// When augmented with zero or more [returnOptions], requests an extended search.
   Future<SortImapResult> sortMessages(String sortCriteria,
-      [String searchCriteria = 'ALL', String charset = 'UTF-8']) {
-    var cmd = Command('SORT ($sortCriteria) $charset $searchCriteria');
-    var parser = SortParser();
+      [String searchCriteria = 'ALL',
+      String charset = 'UTF-8',
+      List<ReturnOption> returnOptions]) {
+    var hasReturnOptions = returnOptions != null;
+    var parser = SortParser(false, hasReturnOptions);
+    Command cmd;
+    var buffer = StringBuffer('SORT ');
+    if (hasReturnOptions) {
+      buffer..write('RETURN (')..write(returnOptions.join(' '))..write(') ');
+    }
+    buffer
+      ..write('(')
+      ..write(sortCriteria)
+      ..write(') ')
+      ..write(charset)
+      ..write(' ')
+      ..write(searchCriteria);
+    final cmdText = buffer.toString();
+    buffer.clear();
+    final sortLines = cmdText.split('\n');
+    if (sortLines.length == 1) {
+      cmd = Command(cmdText);
+    } else {
+      cmd = Command.withContinuation(sortLines);
+    }
     return sendCommand<SortImapResult>(cmd, parser);
   }
 
@@ -1340,10 +1363,33 @@ class ImapClient extends ClientBase {
   /// [sortCriteria] the criteria used for sorting the results like 'ARRIVAL' or 'SUBJECT'
   /// [searchCriteria] the criteria like 'UNSEEN' or 'RECENT'
   /// [charset] the charset used for the searching criteria
+  /// When augmented with zero or more [returnOptions], requests an extended search.
   Future<SortImapResult> uidSortMessages(String sortCriteria,
-      [String searchCriteria = 'ALL', String charset = 'UTF-8']) {
-    var cmd = Command('UID SORT ($sortCriteria) $charset $searchCriteria');
-    var parser = SortParser(true);
+      [String searchCriteria = 'ALL',
+      String charset = 'UTF-8',
+      List<ReturnOption> returnOptions]) {
+    var hasReturnOptions = returnOptions != null;
+    var parser = SortParser(true, hasReturnOptions);
+    Command cmd;
+    var buffer = StringBuffer('UID SORT ');
+    if (hasReturnOptions) {
+      buffer..write('RETURN (')..write(returnOptions.join(' '))..write(') ');
+    }
+    buffer
+      ..write('(')
+      ..write(sortCriteria)
+      ..write(') ')
+      ..write(charset)
+      ..write(' ')
+      ..write(searchCriteria);
+    final cmdText = buffer.toString();
+    buffer.clear();
+    final sortLines = cmdText.split('\n');
+    if (sortLines.length == 1) {
+      cmd = Command(cmdText);
+    } else {
+      cmd = Command.withContinuation(sortLines);
+    }
     return sendCommand<SortImapResult>(cmd, parser);
   }
 

--- a/lib/imap/imap_client.dart
+++ b/lib/imap/imap_client.dart
@@ -835,10 +835,19 @@ class ImapClient extends ClientBase {
   }
 
   /// Searches messages by the given [searchCriteria] like `'UNSEEN'` or `'RECENT'` or `'FROM sender@domain.com'`.
-  Future<SearchImapResult> searchMessages([String searchCriteria = 'UNSEEN']) {
-    var parser = SearchParser(false);
+  /// When augmented with zero or more [returnOptions], requests an extended search.
+  Future<SearchImapResult> searchMessages(
+      [String searchCriteria = 'UNSEEN', List<ReturnOption> returnOptions]) {
+    var hasReturnOptions = returnOptions != null;
+    var parser = SearchParser(false, hasReturnOptions);
     Command cmd;
-    final cmdText = 'SEARCH $searchCriteria';
+    var buffer = StringBuffer('SEARCH ');
+    if (hasReturnOptions) {
+      buffer..write('RETURN (')..write(returnOptions.join(' '))..write(') ');
+    }
+    buffer.write(searchCriteria);
+    final cmdText = buffer.toString();
+    buffer.clear();
     final searchLines = cmdText.split('\n');
     if (searchLines.length == 1) {
       cmd = Command(cmdText);
@@ -855,11 +864,19 @@ class ImapClient extends ClientBase {
 
   /// Searches messages by the given [searchCriteria] like `'UNSEEN'` or `'RECENT'` or `'FROM sender@domain.com'`.
   /// Is only supported by servers that expose the `UID` capability.
+  /// When augmented with zero or more [returnOptions], requests an extended search.
   Future<SearchImapResult> uidSearchMessages(
-      [String searchCriteria = 'UNSEEN']) {
-    var parser = SearchParser(true);
+      [String searchCriteria = 'UNSEEN', List<ReturnOption> returnOptions]) {
+    var hasReturnOptions = returnOptions != null;
+    var parser = SearchParser(true, hasReturnOptions);
     Command cmd;
-    final cmdText = 'UID SEARCH $searchCriteria';
+    var buffer = StringBuffer('UID SEARCH ');
+    if (hasReturnOptions) {
+      buffer..write('RETURN (')..write(returnOptions.join(' '))..write(') ');
+    }
+    buffer.write(searchCriteria);
+    final cmdText = buffer.toString();
+    buffer.clear();
     final searchLines = cmdText.split('\n');
     if (searchLines.length == 1) {
       cmd = Command(cmdText);

--- a/lib/imap/response.dart
+++ b/lib/imap/response.dart
@@ -86,8 +86,23 @@ class SearchImapResult {
   MessageSequence matchingSequence;
 
   /// The highest modification sequence in the searched messages
-  /// The modification sequeqnce can only be returned when the MODSEQ search criteria has been used and when the server supports the CONDSTORE capability.
+  /// The modification sequence can only be returned when the MODSEQ search criteria has been used and when the server supports the CONDSTORE capability.
   int highestModSequence;
+
+  /// Identifies an extended search result
+  bool isExtended;
+
+  /// Result tag
+  String tag;
+
+  /// Minimum found message ID or UID
+  int min;
+
+  /// Maximum found message ID or UID
+  int max;
+
+  /// Matches count
+  int count;
 }
 
 class UidResponseCode {

--- a/lib/imap/response.dart
+++ b/lib/imap/response.dart
@@ -154,4 +154,19 @@ class SortImapResult {
   /// The highest modification sequence in the searched messages
   /// The modification sequeqnce can only be returned when the MODSEQ search criteria has been used and when the server supports the CONDSTORE capability.
   int highestModSequence;
+
+  /// Signals an extended sort result
+  bool isExtended;
+
+  /// Result tag
+  String tag;
+
+  /// Minimum found message ID or UID
+  int min;
+
+  /// Maximum found message ID or UID
+  int max;
+
+  /// Matches count
+  int count;
 }

--- a/lib/imap/response.dart
+++ b/lib/imap/response.dart
@@ -103,6 +103,11 @@ class SearchImapResult {
 
   /// Matches count
   int count;
+
+  /// Range of the partial result returned
+  String partialRange;
+
+  bool get isPartial => partialRange != null && partialRange.isNotEmpty;
 }
 
 class UidResponseCode {
@@ -169,4 +174,9 @@ class SortImapResult {
 
   /// Matches count
   int count;
+
+  /// Range of the partial result returned
+  String partialRange;
+
+  bool get isPartial => partialRange != null && partialRange.isNotEmpty;
 }

--- a/lib/imap/return_option.dart
+++ b/lib/imap/return_option.dart
@@ -1,0 +1,41 @@
+/// Return option definition for extended commands.
+class ReturnOption {
+  final String name;
+
+  /// Optional list of return option parameters.
+  final List<String> _parameters;
+
+  ReturnOption(this.name, [this._parameters]);
+
+  /// Returns the minimum message id or UID that satisfies the search parameters.
+  ReturnOption.min() : this('MIN');
+
+  /// Return the maximum message id or UID that satisfies the search parameters.
+  ReturnOption.max() : this('MAX');
+
+  /// Returns all the message ids or UIDs that satisfies the search parameters.
+  ReturnOption.all() : this('ALL');
+
+  /// Returns the match count of the search request.
+  ReturnOption.count() : this('COUNT');
+
+  void add(String parameter) {
+    _parameters?.add(parameter);
+  }
+
+  void addAll(List<String> parameters) {
+    _parameters?.addAll(parameters);
+  }
+
+  bool hasParameter(String parameter) =>
+      _parameters?.contains(parameter) ?? false;
+
+  @override
+  String toString() {
+    final result = StringBuffer(name);
+    if (_parameters != null && _parameters.isNotEmpty) {
+      result..write(' (')..write(_parameters.join(' '))..write(')');
+    }
+    return result.toString();
+  }
+}

--- a/lib/src/imap/search_parser.dart
+++ b/lib/src/imap/search_parser.dart
@@ -10,7 +10,14 @@ class SearchParser extends ResponseParser<SearchImapResult> {
   List<int> ids = <int>[];
   int highestModSequence;
 
-  SearchParser(this.isUidSearch);
+  final bool isExtended;
+  // Reference tag for the current extended search untagged response
+  String tag;
+  int min;
+  int max;
+  int count;
+
+  SearchParser(this.isUidSearch, [this.isExtended = false]);
 
   @override
   SearchImapResult parse(
@@ -20,7 +27,12 @@ class SearchParser extends ResponseParser<SearchImapResult> {
         // Force the sorting of the resulting sequence set
         ..matchingSequence =
             (MessageSequence.fromIds(ids, isUid: isUidSearch)..sorted())
-        ..highestModSequence = highestModSequence;
+        ..highestModSequence = highestModSequence
+        ..isExtended = isExtended
+        ..tag = tag
+        ..min = min
+        ..max = max
+        ..count = count;
       return result;
     }
     return null;
@@ -31,27 +43,65 @@ class SearchParser extends ResponseParser<SearchImapResult> {
       ImapResponse imapResponse, Response<SearchImapResult> response) {
     var details = imapResponse.parseText;
     if (details.startsWith('SEARCH ')) {
-      var listEntries = parseListEntries(details, 'SEARCH '.length, null);
-      for (var i = 0; i < listEntries.length; i++) {
-        var entry = listEntries[i];
-        if (entry == '(MODSEQ') {
-          i++;
-          entry = listEntries[i];
-          var modSeqText = entry.substring(0, entry.length - 1);
-          highestModSequence = int.tryParse(modSeqText);
-        } else {
-          var id = int.tryParse(entry);
-          if (id != null) {
-            ids.add(id);
-          }
-        }
-      }
-      return true;
-    } else if (details == 'SEARCH') {
+      return _parseSimpleDetails(details);
+    } else if (details.startsWith('ESEARCH ')) {
+      return _parseExtendedDetails(details);
+    } else if (details == 'SEARCH' || details == 'ESEARCH') {
       // this is an empty search result
       return true;
     } else {
       return super.parseUntagged(imapResponse, response);
     }
+  }
+
+  bool _parseSimpleDetails(String details) {
+    var listEntries = parseListEntries(details, 'SEARCH '.length, null);
+    for (var i = 0; i < listEntries.length; i++) {
+      var entry = listEntries[i];
+      if (entry == '(MODSEQ') {
+        i++;
+        entry = listEntries[i];
+        var modSeqText = entry.substring(0, entry.length - 1);
+        highestModSequence = int.tryParse(modSeqText);
+      } else {
+        var id = int.tryParse(entry);
+        if (id != null) {
+          ids.add(id);
+        }
+      }
+    }
+    return true;
+  }
+
+  bool _parseExtendedDetails(String details) {
+    var listEntries = parseListEntries(details, 'ESEARCH '.length, null);
+    for (var i = 0; i < listEntries.length; i++) {
+      var entry = listEntries[i];
+      if (entry == '(TAG') {
+        i++;
+        entry = listEntries[i];
+        tag = entry.substring(1, entry.length - 1);
+      } else if (entry == 'UID') {
+        // Included for completeness.
+      } else if (entry == 'MIN') {
+        i++;
+        min = int.tryParse(listEntries[i]);
+      } else if (entry == 'MAX') {
+        i++;
+        max = int.tryParse(listEntries[i]);
+      } else if (entry == 'COUNT') {
+        i++;
+        count = int.tryParse(listEntries[i]);
+      } else if (entry == 'ALL') {
+        i++;
+        // The result is always sequence-set.
+        ids = MessageSequence.parse(listEntries[i], isUidSequence: isUidSearch)
+            .toList();
+      } else if (entry == 'MODSEQ') {
+        i++;
+        highestModSequence = int.tryParse(listEntries[i]);
+      }
+    }
+    return true;
   }
 }

--- a/lib/src/imap/search_parser.dart
+++ b/lib/src/imap/search_parser.dart
@@ -17,6 +17,8 @@ class SearchParser extends ResponseParser<SearchImapResult> {
   int max;
   int count;
 
+  String partialRange;
+
   SearchParser(this.isUidSearch, [this.isExtended = false]);
 
   @override
@@ -32,7 +34,8 @@ class SearchParser extends ResponseParser<SearchImapResult> {
         ..tag = tag
         ..min = min
         ..max = max
-        ..count = count;
+        ..count = count
+        ..partialRange = partialRange;
       return result;
     }
     return null;
@@ -80,7 +83,7 @@ class SearchParser extends ResponseParser<SearchImapResult> {
       if (entry == '(TAG') {
         i++;
         entry = listEntries[i];
-        tag = entry.substring(1, entry.length - 1);
+        tag = entry.substring(1, entry.length - 2);
       } else if (entry == 'UID') {
         // Included for completeness.
       } else if (entry == 'MIN') {
@@ -100,6 +103,12 @@ class SearchParser extends ResponseParser<SearchImapResult> {
       } else if (entry == 'MODSEQ') {
         i++;
         highestModSequence = int.tryParse(listEntries[i]);
+      } else if (entry == 'PARTIAL') {
+        i++;
+        partialRange = listEntries[i];
+        i++;
+        ids = MessageSequence.parse(listEntries[i], isUidSequence: isUidSearch)
+            .toList();
       }
     }
     return true;

--- a/lib/src/imap/sort_parser.dart
+++ b/lib/src/imap/sort_parser.dart
@@ -17,6 +17,8 @@ class SortParser extends ResponseParser<SortImapResult> {
   int max;
   int count;
 
+  String partialRange;
+
   SortParser([this.isUidSort = false, this.isExtended = false]);
 
   @override
@@ -30,7 +32,8 @@ class SortParser extends ResponseParser<SortImapResult> {
         ..tag = tag
         ..min = min
         ..max = max
-        ..count = count;
+        ..count = count
+        ..partialRange = partialRange;
       return result;
     }
     return null;
@@ -98,6 +101,12 @@ class SortParser extends ResponseParser<SortImapResult> {
       } else if (entry == 'MODSEQ') {
         i++;
         highestModSequence = int.tryParse(listEntries[i]);
+      } else if (entry == 'PARTIAL') {
+        i++;
+        partialRange = listEntries[i];
+        i++;
+        ids = MessageSequence.parse(listEntries[i], isUidSequence: isUidSort)
+            .toList();
       }
     }
     return true;

--- a/lib/src/imap/sort_parser.dart
+++ b/lib/src/imap/sort_parser.dart
@@ -10,7 +10,14 @@ class SortParser extends ResponseParser<SortImapResult> {
   List<int> ids = <int>[];
   int highestModSequence;
 
-  SortParser([this.isUidSort = false]);
+  bool isExtended;
+  // Reference tag for the current extended sort untagged response
+  String tag;
+  int min;
+  int max;
+  int count;
+
+  SortParser([this.isUidSort = false, this.isExtended = false]);
 
   @override
   SortImapResult parse(
@@ -18,7 +25,12 @@ class SortParser extends ResponseParser<SortImapResult> {
     if (response.isOkStatus) {
       var result = SortImapResult()
         ..matchingSequence = MessageSequence.fromIds(ids, isUid: isUidSort)
-        ..highestModSequence = highestModSequence;
+        ..highestModSequence = highestModSequence
+        ..isExtended = isExtended
+        ..tag = tag
+        ..min = min
+        ..max = max
+        ..count = count;
       return result;
     }
     return null;
@@ -29,28 +41,65 @@ class SortParser extends ResponseParser<SortImapResult> {
       ImapResponse imapResponse, Response<SortImapResult> response) {
     var details = imapResponse.parseText;
     if (details.startsWith('SORT ')) {
-      var listEntries = parseListEntries(details, 'SORT '.length, null);
-      for (var i = 0; i < listEntries.length; i++) {
-        var entry = listEntries[i];
-        // Maybe MODSEQ should not be supported by SORT (introduced by ESORT?)
-        if (entry == '(MODSEQ') {
-          i++;
-          entry = listEntries[i];
-          var modSeqText = entry.substring(0, entry.length - 1);
-          highestModSequence = int.tryParse(modSeqText);
-        } else {
-          var id = int.tryParse(entry);
-          if (id != null) {
-            ids.add(id);
-          }
-        }
-      }
-      return true;
-    } else if (details == 'SORT') {
+      return _parseSimpleDetails(details);
+    } else if (details.startsWith('ESEARCH ')) {
+      return _parseExtendedDetails(details);
+    } else if (details == 'SORT' || details == 'ESEARCH') {
       // this is an empty search result
       return true;
     } else {
       return super.parseUntagged(imapResponse, response);
     }
+  }
+
+  bool _parseSimpleDetails(String details) {
+    var listEntries = parseListEntries(details, 'SORT '.length, null);
+    for (var i = 0; i < listEntries.length; i++) {
+      var entry = listEntries[i];
+      // Maybe MODSEQ should not be supported by SORT (introduced by ESORT?)
+      if (entry == '(MODSEQ') {
+        i++;
+        entry = listEntries[i];
+        var modSeqText = entry.substring(0, entry.length - 1);
+        highestModSequence = int.tryParse(modSeqText);
+      } else {
+        var id = int.tryParse(entry);
+        if (id != null) {
+          ids.add(id);
+        }
+      }
+    }
+    return true;
+  }
+
+  bool _parseExtendedDetails(String details) {
+    var listEntries = parseListEntries(details, 'ESEARCH '.length, null);
+    for (var i = 0; i < listEntries.length; i++) {
+      var entry = listEntries[i];
+      if (entry == '(TAG') {
+        i++;
+        entry = listEntries[i];
+        tag = entry.substring(1, entry.length - 2);
+      } else if (entry == 'UID') {
+        // Inclided for completeness.
+      } else if (entry == 'MIN') {
+        i++;
+        min = int.tryParse(listEntries[i]);
+      } else if (entry == 'MAX') {
+        i++;
+        max = int.tryParse(listEntries[i]);
+      } else if (entry == 'COUNT') {
+        i++;
+        count = int.tryParse(listEntries[i]);
+      } else if (entry == 'ALL') {
+        i++;
+        ids = MessageSequence.parse(listEntries[i], isUidSequence: isUidSort)
+            .toList();
+      } else if (entry == 'MODSEQ') {
+        i++;
+        highestModSequence = int.tryParse(listEntries[i]);
+      }
+    }
+    return true;
   }
 }

--- a/test/imap/imap_client_test.dart
+++ b/test/imap/imap_client_test.dart
@@ -450,6 +450,88 @@ void main() {
     }
   });
 
+  test('ImapClient extended sort', () async {
+    final testSequence = [
+      184,
+      182,
+      183,
+      181,
+      180,
+      179,
+      178,
+      177,
+      176,
+      175,
+      174,
+      173,
+      172,
+      171,
+      170,
+      169,
+      168,
+      167,
+      166,
+      164,
+      163
+    ];
+    _log('');
+    if (mockServer != null) {
+      mockInbox.messageSequenceIdsSorted = testSequence;
+    }
+    var sortResponse = await client.sortMessages(
+        'ARRIVAL', 'ALL', 'UTF-8', [ReturnOption.count(), ReturnOption.all()]);
+    expect(sortResponse.matchingSequence, isNotNull);
+    expect(sortResponse.matchingSequence.isNotEmpty(), true);
+    _log('sorted messages: ' + sortResponse.toString());
+    if (mockServer != null) {
+      expect(sortResponse.matchingSequence.length,
+          mockInbox.messageSequenceIdsSorted.length);
+      expect(sortResponse.matchingSequence.toList(), testSequence);
+      expect(sortResponse.count, testSequence.length);
+    }
+  });
+
+  test('ImapClient extended uid sort', () async {
+    final testSequence = [
+      184,
+      182,
+      183,
+      181,
+      180,
+      179,
+      178,
+      177,
+      176,
+      175,
+      174,
+      173,
+      172,
+      171,
+      170,
+      169,
+      168,
+      167,
+      166,
+      164,
+      163
+    ];
+    _log('');
+    if (mockServer != null) {
+      mockInbox.messageSequenceIdsSorted = testSequence;
+    }
+    var sortResponse = await client.uidSortMessages(
+        'ARRIVAL', 'ALL', 'UTF-8', [ReturnOption.count(), ReturnOption.all()]);
+    expect(sortResponse.matchingSequence, isNotNull);
+    expect(sortResponse.matchingSequence.isNotEmpty(), true);
+    _log('sorted messages: ' + sortResponse.toString());
+    if (mockServer != null) {
+      expect(sortResponse.matchingSequence.length,
+          mockInbox.messageSequenceIdsSorted.length);
+      expect(sortResponse.matchingSequence.toList(), testSequence);
+      expect(sortResponse.count, testSequence.length);
+    }
+  });
+
   test('ImapClient fetch FULL', () async {
     _log('');
     var lowerIndex = math.max(inbox.messagesExists - 1, 0);

--- a/test/imap/imap_client_test.dart
+++ b/test/imap/imap_client_test.dart
@@ -402,6 +402,54 @@ void main() {
     }
   });
 
+  test('ImapClient extended search', () async {
+    _log('');
+    if (mockServer != null) {
+      mockInbox.messageSequenceIdsUnseen = [
+        mockInbox.firstUnseenMessageSequenceId,
+        3423,
+        17,
+        3
+      ];
+    }
+    var searchResponse = await client
+        .searchMessages('UNSEEN', [ReturnOption.count(), ReturnOption.all()]);
+    expect(searchResponse.matchingSequence, isNotNull);
+    expect(searchResponse.matchingSequence.isNotEmpty(), true);
+    _log('searched messages: ' + searchResponse.toString());
+    if (mockServer != null) {
+      expect(searchResponse.matchingSequence.length,
+          mockInbox.messageSequenceIdsUnseen.length);
+      expect(searchResponse.count, 4);
+      expect(searchResponse.matchingSequence.toList(),
+          [3, 17, 3423, mockInbox.firstUnseenMessageSequenceId]);
+    }
+  });
+
+  test('ImapClient extended uid search', () async {
+    _log('');
+    if (mockServer != null) {
+      mockInbox.messageSequenceIdsUnseen = [
+        mockInbox.firstUnseenMessageSequenceId,
+        3423,
+        17,
+        3
+      ];
+    }
+    var searchResponse = await client.uidSearchMessages(
+        'UNSEEN', [ReturnOption.all(), ReturnOption.count()]);
+    expect(searchResponse.matchingSequence, isNotNull);
+    expect(searchResponse.matchingSequence.isNotEmpty(), true);
+    _log('searched messages: ' + searchResponse.toString());
+    if (mockServer != null) {
+      expect(searchResponse.matchingSequence.length,
+          mockInbox.messageSequenceIdsUnseen.length);
+      expect(searchResponse.count, 4);
+      expect(searchResponse.matchingSequence.toList(),
+          [3, 17, 3423, mockInbox.firstUnseenMessageSequenceId]);
+    }
+  });
+
   test('ImapClient fetch FULL', () async {
     _log('');
     var lowerIndex = math.max(inbox.messagesExists - 1, 0);

--- a/test/src/imap/search_parser_test.dart
+++ b/test/src/imap/search_parser_test.dart
@@ -44,4 +44,50 @@ void main() {
     expect(ids, [2, 5, 6, 7, 11, 12, 18, 19, 20, 23]);
     expect(result.highestModSequence, 917162500);
   });
+
+  test('Extended search with MIN, MAX, COUNT', () {
+    var responseText = 'ESEARCH (TAG "C1") MIN 2 MAX 47 COUNT 25';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SearchParser(false, true);
+    var response = Response<SearchImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    expect(result.isExtended, true);
+    expect(result.min, 2);
+    expect(result.max, 47);
+    expect(result.count, 25);
+    expect(result.tag, 'C1');
+  });
+
+  test('Extended search with COUNT, ALL', () {
+    var responseText = 'ESEARCH (TAG "C2") COUNT 25 ALL 2,4,10:18,24,25,26';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SearchParser(false, true);
+    var response = Response<SearchImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    var ids = result.matchingSequence.toList();
+    expect(result.isExtended, true);
+    expect(result.count, 25);
+    expect(result.tag, 'C2');
+    expect(ids, [2, 4, 10, 11, 12, 13, 14, 15, 16, 17, 18, 24, 25, 26]);
+  });
+
+  test('Extended search with MIN, MAX, MODSEQ', () {
+    var responseText = 'ESEARCH (TAG "C3") MIN 1 MAX 18 MODSEQ 123456';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SearchParser(false, true);
+    var response = Response<SearchImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    var ids = result.matchingSequence.toList();
+    expect(result.isExtended, true);
+    expect(result.min, 1);
+    expect(result.max, 18);
+    expect(result.tag, 'C3');
+    expect(result.highestModSequence, 123456);
+  });
 }

--- a/test/src/imap/search_parser_test.dart
+++ b/test/src/imap/search_parser_test.dart
@@ -90,4 +90,19 @@ void main() {
     expect(result.tag, 'C3');
     expect(result.highestModSequence, 123456);
   });
+
+  test('Extended search with PARTIAL', () {
+    var responseText = 'ESEARCH (TAG "C4") PARTIAL 1:10 3,5,7,9';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SearchParser(false, true);
+    var response = Response<SearchImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    var ids = result.matchingSequence.toList();
+    expect(result.isExtended, true);
+    expect(result.tag, 'C4');
+    expect(result.partialRange, '1:10');
+    expect(ids, [3, 5, 7, 9]);
+  });
 }

--- a/test/src/imap/sort_parser_test.dart
+++ b/test/src/imap/sort_parser_test.dart
@@ -1,0 +1,94 @@
+import 'package:enough_mail/imap/response.dart';
+import 'package:enough_mail/src/imap/imap_response.dart';
+import 'package:enough_mail/src/imap/imap_response_line.dart';
+import 'package:enough_mail/src/imap/sort_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Sort simple', () {
+    var responseText = 'SORT 7 5 8 18 19 20 34 33 32 30 10';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SortParser(false);
+    var response = Response<SortImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var ids = parser.parse(details, response).matchingSequence.toList();
+    expect(ids, isNotNull);
+    expect(ids, isNotEmpty);
+    expect(ids, [7, 5, 8, 18, 19, 20, 34, 33, 32, 30, 10]);
+  });
+
+  test('Sort empty', () {
+    var responseText = 'SORT';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SortParser(false);
+    var response = Response<SortImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var ids = parser.parse(details, response).matchingSequence.toList();
+    expect(ids, isNotNull);
+    expect(ids, isEmpty);
+  });
+
+  test('Sort with mod sequence', () {
+    var responseText = 'SORT 7 5 8 18 19 20 34 33 32 30 10 (MODSEQ 917162500)';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SortParser(false);
+    var response = Response<SortImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    var ids = parser.parse(details, response).matchingSequence.toList();
+    expect(ids, isNotNull);
+    expect(ids, isNotEmpty);
+    expect(ids, [7, 5, 8, 18, 19, 20, 34, 33, 32, 30, 10]);
+    expect(result.highestModSequence, 917162500);
+  });
+
+  test('Extended sort with MIN, MAX, COUNT', () {
+    var responseText = 'ESEARCH (TAG "C1") MIN 2 MAX 47 COUNT 25';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SortParser(false, true);
+    var response = Response<SortImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    expect(result.isExtended, true);
+    expect(result.tag, 'C1');
+    expect(result.min, 2);
+    expect(result.max, 47);
+    expect(result.count, 25);
+  });
+
+  test('Extended sort with COUNT, ALL', () {
+    var responseText =
+        'ESEARCH (TAG "C2") ALL 7,5,8,18:20,34,33,32,30,10 COUNT 11';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SortParser(false, true);
+    var response = Response<SortImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    var ids = result.matchingSequence.toList();
+    expect(result.isExtended, true);
+    expect(result.tag, 'C2');
+    expect(result.count, 11);
+    expect(ids.length, result.count);
+    expect(ids, [7, 5, 8, 18, 19, 20, 34, 33, 32, 30, 10]);
+  });
+
+  test('Extended sort with MIN, MAX, MODSEQ', () {
+    var responseText = 'ESEARCH (TAG "C3") MIN 2 MAX 47 MODSEQ 123456';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SortParser(false, true);
+    var response = Response<SortImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    expect(result.isExtended, true);
+    expect(result.tag, 'C3');
+    expect(result.min, 2);
+    expect(result.max, 47);
+    expect(result.highestModSequence, 123456);
+  });
+}

--- a/test/src/imap/sort_parser_test.dart
+++ b/test/src/imap/sort_parser_test.dart
@@ -91,4 +91,19 @@ void main() {
     expect(result.max, 47);
     expect(result.highestModSequence, 123456);
   });
+
+  test('Extended sort with PARTIAL', () {
+    var responseText = 'ESEARCH (TAG "C4") PARTIAL 1:10 3,9,7,5';
+    var details = ImapResponse()..add(ImapResponseLine(responseText));
+    var parser = SortParser(false, true);
+    var response = Response<SortImapResult>()..status = ResponseStatus.OK;
+    var processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    var result = parser.parse(details, response);
+    var ids = result.matchingSequence.toList();
+    expect(result.isExtended, true);
+    expect(result.tag, 'C4');
+    expect(result.partialRange, '1:10');
+    expect(ids, [3, 9, 7, 5]);
+  });
 }


### PR DESCRIPTION
Adds the ESEARCH extension support (closes #45).
Also from the [Contexts](https://tools.ietf.org/html/rfc5267) extension, the ESORT command and the PARTIAL return option.
