### PR TITLE
Fix handling of NIL sequence set in SEARCH and SORT

### DIFF
--- a/lib/imap/message_sequence.dart
+++ b/lib/imap/message_sequence.dart
@@ -273,6 +273,7 @@ class MessageSequence {
     var chunks = text.split(',');
     if (chunks[0] == 'NIL') {
       sequence._isNilSequence = true;
+      sequence._text = null;
     } else {
       for (var chunk in chunks) {
         var id = int.tryParse(chunk);

--- a/lib/src/imap/search_parser.dart
+++ b/lib/src/imap/search_parser.dart
@@ -98,8 +98,11 @@ class SearchParser extends ResponseParser<SearchImapResult> {
       } else if (entry == 'ALL') {
         i++;
         // The result is always sequence-set.
-        ids = MessageSequence.parse(listEntries[i], isUidSequence: isUidSearch)
-            .toList();
+        var seq =
+            MessageSequence.parse(listEntries[i], isUidSequence: isUidSearch);
+        if (seq.isNil) {
+          ids = seq.toList();
+        }
       } else if (entry == 'MODSEQ') {
         i++;
         highestModSequence = int.tryParse(listEntries[i]);
@@ -107,8 +110,11 @@ class SearchParser extends ResponseParser<SearchImapResult> {
         i++;
         partialRange = listEntries[i];
         i++;
-        ids = MessageSequence.parse(listEntries[i], isUidSequence: isUidSearch)
-            .toList();
+        var seq =
+            MessageSequence.parse(listEntries[i], isUidSequence: isUidSearch);
+        if (seq.isNil) {
+          ids = seq.toList();
+        }
       }
     }
     return true;

--- a/lib/src/imap/sort_parser.dart
+++ b/lib/src/imap/sort_parser.dart
@@ -96,8 +96,11 @@ class SortParser extends ResponseParser<SortImapResult> {
         count = int.tryParse(listEntries[i]);
       } else if (entry == 'ALL') {
         i++;
-        ids = MessageSequence.parse(listEntries[i], isUidSequence: isUidSort)
-            .toList();
+        var seq =
+            MessageSequence.parse(listEntries[i], isUidSequence: isUidSort);
+        if (seq.isNil) {
+          ids = seq.toList();
+        }
       } else if (entry == 'MODSEQ') {
         i++;
         highestModSequence = int.tryParse(listEntries[i]);
@@ -105,8 +108,11 @@ class SortParser extends ResponseParser<SortImapResult> {
         i++;
         partialRange = listEntries[i];
         i++;
-        ids = MessageSequence.parse(listEntries[i], isUidSequence: isUidSort)
-            .toList();
+        var seq =
+            MessageSequence.parse(listEntries[i], isUidSequence: isUidSort);
+        if (seq.isNil) {
+          ids = seq.toList();
+        }
       }
     }
     return true;

--- a/test/imap/message_sequence_test.dart
+++ b/test/imap/message_sequence_test.dart
@@ -226,6 +226,10 @@ void main() {
       var sequence = MessageSequence.parse('17:*,5');
       expect(sequence.toString(), '17:*,5');
     });
+    test('NIL', () {
+      var sequence = MessageSequence.parse('NIL');
+      expect(sequence.toString(), 'NIL');
+    });
   });
 
   group('Parse sorted', () {
@@ -293,6 +297,10 @@ void main() {
       sequence.addRange(5, 8);
       sequence.add(3);
       expect(sequence.toList(20), [17, 18, 19, 20, 5, 6, 7, 8, 3]);
+    });
+    test('NIL', () {
+      var sequence = MessageSequence.parse('NIL');
+      expect(() => sequence.toList(), throwsStateError);
     });
   });
 


### PR DESCRIPTION
Avoids the StateError when calling `.toList()` on a `MessageSequence` from an unsuccessful search while parsing the response.