### PR TITLE
List extensions (rfc5258, rfc5819, rfc6154)

### DIFF
--- a/lib/enough_mail.dart
+++ b/lib/enough_mail.dart
@@ -11,6 +11,7 @@ export 'imap/metadata.dart';
 export 'imap/qresync.dart';
 export 'imap/resource_limit.dart';
 export 'imap/return_option.dart';
+export 'imap/selection_options.dart';
 
 export 'pop/pop_client.dart';
 export 'pop/pop_events.dart';

--- a/lib/imap/extended_data.dart
+++ b/lib/imap/extended_data.dart
@@ -1,0 +1,5 @@
+/// Extended data results for LIST commands.
+class ExtendedData {
+  /// Child informations as result of "RECURSIVEMATCH" extended selection option
+  static const String childinfo = 'CHILDINFO';
+}

--- a/lib/imap/mailbox.dart
+++ b/lib/imap/mailbox.dart
@@ -54,6 +54,9 @@ class Mailbox {
   List<String> messageFlags;
   List<String> permanentMessageFlags;
 
+  /// Map of extended results
+  Map<String, List<String>> extendedData = {};
+
   /// This is set to false in case the server supports CONDSTORE but no mod sequence for this mailbox
   bool hasModSequence;
 

--- a/lib/imap/return_option.dart
+++ b/lib/imap/return_option.dart
@@ -10,6 +10,18 @@ class ReturnOption {
 
   ReturnOption(this.name, [this._parameters, this._isSingleParam = false]);
 
+  ReturnOption.specialUse() : this('SPECIAL-USE');
+
+  /// Returns subscription state of all matching mailbox names.
+  ReturnOption.subscribed() : this('SUBSCRIBED');
+
+  /// Returns mailbox child information as flags "\HasChildren", "\HasNoChildren".
+  ReturnOption.children() : this('CHILDREN');
+
+  /// Returns given STATUS informations of all matching mailbox names.
+  /// A number of [attributes] must be provided for returning their status.
+  ReturnOption.status([List<String> parameters]) : this('STATUS', parameters);
+
   /// Returns the minimum message id or UID that satisfies the search parameters.
   ReturnOption.min() : this('MIN');
 
@@ -23,7 +35,7 @@ class ReturnOption {
   ReturnOption.count() : this('COUNT');
 
   /// Defines a partial range of the found results.
-  ReturnOption.partial(rangeSet) : this('PARTIAL', [rangeSet], true);
+  ReturnOption.partial(String rangeSet) : this('PARTIAL', [rangeSet], true);
 
   void add(String parameter) {
     if (_parameters == null) {

--- a/lib/imap/selection_options.dart
+++ b/lib/imap/selection_options.dart
@@ -1,0 +1,32 @@
+/// LIST-EXTENDED selection options
+enum SelectionOptions {
+  /// Includes flags for special-use mailboxes, such as those used to hold draft messages or sent messages.
+  specialUse,
+
+  /// List only subscribed names. Supplements the LSUB command but with accurate and complete informations.
+  subscribed,
+
+  /// Shows also remote mailboxes, marked with "\Remote" attribute.
+  remote,
+
+  /// Forces the return of informations about non matched mailboxes whose children matches the selection options.
+  ///
+  /// Cannot be uses alone or in combination with only the REMOTE option
+  recursiveMatch,
+}
+
+extension Stringify on SelectionOptions {
+  String value() {
+    switch (this) {
+      case SelectionOptions.specialUse:
+        return 'SPECIAL-USE';
+      case SelectionOptions.subscribed:
+        return 'SUBSCRIBED';
+      case SelectionOptions.remote:
+        return 'REMOTE';
+      case SelectionOptions.recursiveMatch:
+        return 'RECURSIVEMATCH';
+    }
+    throw UnsupportedError('Invalid LIST selection option');
+  }
+}

--- a/lib/src/imap/list_parser.dart
+++ b/lib/src/imap/list_parser.dart
@@ -1,7 +1,9 @@
+import 'package:enough_mail/imap/extended_data.dart';
 import 'package:enough_mail/imap/imap_client.dart';
 import 'package:enough_mail/imap/mailbox.dart';
 import 'package:enough_mail/imap/response.dart';
 import 'package:enough_mail/src/imap/response_parser.dart';
+import 'package:enough_mail/src/imap/status_parser.dart';
 
 import 'imap_response.dart';
 
@@ -10,9 +12,16 @@ class ListParser extends ResponseParser<List<Mailbox>> {
   final ImapServerInfo info;
   final List<Mailbox> boxes = <Mailbox>[];
   String startSequence;
+  final bool isExtended;
+  bool _hasReturnOptions = false;
 
-  ListParser(this.info, {bool isLsubParser = false}) {
+  ListParser(this.info,
+      {bool isLsubParser = false,
+      this.isExtended = false,
+      bool hasReturnOptions = false}) {
     startSequence = isLsubParser ? 'LSUB ' : 'LIST ';
+    // Return options are available only for LIST responses.
+    _hasReturnOptions = !isLsubParser && hasReturnOptions;
   }
 
   @override
@@ -62,9 +71,15 @@ class ListParser extends ResponseParser<List<Mailbox>> {
                 break;
               case r'\noinferiors':
                 box.flags.add(MailboxFlag.noInferior);
+                if (isExtended) {
+                  box.flags.add(MailboxFlag.hasNoChildren);
+                }
                 break;
               case r'\nonexistent':
                 box.flags.add(MailboxFlag.nonExistent);
+                if (isExtended) {
+                  box.flags.add(MailboxFlag.noSelect);
+                }
                 break;
               case r'\subscribed':
                 box.flags.add(MailboxFlag.subscribed);
@@ -117,6 +132,40 @@ class ListParser extends ResponseParser<List<Mailbox>> {
         }
         listDetails = listDetails.substring(flagsEndIndex + 2);
       }
+      // Parses extended data
+      if (isExtended) {
+        var extraInfoStartIndex = listDetails.indexOf('(');
+        var extraInfoEndIndex = listDetails.lastIndexOf(')');
+        if (extraInfoEndIndex != -1 &&
+            extraInfoStartIndex < extraInfoEndIndex) {
+          var extraInfo =
+              listDetails.substring(extraInfoStartIndex + 1, extraInfoEndIndex);
+          listDetails = listDetails.substring(0, extraInfoStartIndex - 1);
+          // Convert to loop if more extended data results will be present
+          // FIXME Address when multiple extended data list are returned by non conforming servers
+          //while (extraInfo.isNotEmpty) {
+          if (extraInfo.startsWith('${ExtendedData.childinfo}') ||
+              extraInfo.startsWith('"${ExtendedData.childinfo}"')) {
+            if (!box.extendedData.containsKey(ExtendedData.childinfo)) {
+              box.extendedData[ExtendedData.childinfo] = [];
+            }
+            var optsStartIndex = extraInfo.indexOf('(');
+            var optsEndIndex = extraInfo.indexOf(')');
+            if (optsStartIndex != -1 && optsStartIndex < optsEndIndex) {
+              var opts = extraInfo
+                  .substring(optsStartIndex + 1, optsEndIndex)
+                  .split(' ')
+                  .map((e) => e.substring(1, e.length - 1));
+              box.extendedData[ExtendedData.childinfo].addAll(opts);
+            }
+            /* if (optsEndIndex + 1 == extraInfo.length) {
+              break;
+            }
+            extraInfo = extraInfo.substring(optsEndIndex + 2); */
+          }
+          // }
+        }
+      }
       if (listDetails.startsWith('"')) {
         var endOfPathSeparatorIndex = listDetails.indexOf('"', 1);
         if (endOfPathSeparatorIndex != -1) {
@@ -133,14 +182,30 @@ class ListParser extends ResponseParser<List<Mailbox>> {
       if (listDetails.toUpperCase() == 'INBOX' && !box.isInbox) {
         box.flags.add(MailboxFlag.inbox);
       }
-      var lastPathSeparatorIndex =
-          listDetails.lastIndexOf(info.pathSeparator, listDetails.length - 2);
-      if (lastPathSeparatorIndex != -1) {
-        listDetails = listDetails.substring(lastPathSeparatorIndex + 1);
+      // Maybe was requested only the hierarchy separator without reference name
+      if (listDetails.isNotEmpty) {
+        var lastPathSeparatorIndex =
+            listDetails.lastIndexOf(info.pathSeparator, listDetails.length - 2);
+        if (lastPathSeparatorIndex != -1) {
+          listDetails = listDetails.substring(lastPathSeparatorIndex + 1);
+        }
       }
       box.name = listDetails;
       boxes.add(box);
       return true;
+    } else if (_hasReturnOptions) {
+      if (details.startsWith('NO')) {
+        // Swallows failed STATUS result
+        // This is a special case in which a STATUS result fails with 'NO' for a
+        // non existent folder. Nevertheless, the mailbox is added with a \Nonexistent flag.
+        return true;
+      }
+      if (details.startsWith('STATUS')) {
+        // Reuses the StatusParser class
+        final parser = StatusParser(boxes.last);
+        parser.parseUntagged(imapResponse, null);
+        return true;
+      }
     }
     return super.parseUntagged(imapResponse, response);
   }

--- a/test/src/imap/list_parser_test.dart
+++ b/test/src/imap/list_parser_test.dart
@@ -117,4 +117,27 @@ void main() {
     expect(mboxes[0].extendedData, contains('CHILDINFO'));
     expect(mboxes[0].extendedData['CHILDINFO'], contains('SUBSCRIBED'));
   });
+
+  test('List with return STATUS response', () {
+    final lines = [
+      r'LIST () "."  "INBOX"',
+      r'STATUS "INBOX" (MESSAGES 17 UNSEEN 16)',
+      r'LIST () "." "foo"',
+      r'STATUS "foo" (MESSAGES 30 UNSEEN 29)',
+      r'LIST (\NoSelect) "." "bar"',
+    ];
+    var details = <ImapResponse>[];
+    lines.forEach(
+        (raw) => details.add(ImapResponse()..add(ImapResponseLine(raw))));
+    var parser =
+        ListParser(serverInfo, isExtended: true, hasReturnOptions: true);
+    var response = _parseListResponse(parser, details);
+    var mboxes = parser.parse(null, response);
+    expect(mboxes.length, 3);
+    expect(mboxes[0].messagesExists, 17);
+    expect(mboxes[0].messagesUnseen, 16);
+    expect(mboxes[1].messagesExists, 30);
+    expect(mboxes[1].messagesUnseen, 29);
+    expect(mboxes[2].flags, contains(MailboxFlag.noSelect));
+  });
 }

--- a/test/src/imap/list_parser_test.dart
+++ b/test/src/imap/list_parser_test.dart
@@ -1,0 +1,120 @@
+import 'package:enough_mail/imap/imap_client.dart';
+import 'package:enough_mail/imap/mailbox.dart';
+import 'package:enough_mail/imap/response.dart';
+import 'package:enough_mail/src/imap/imap_response.dart';
+import 'package:enough_mail/src/imap/imap_response_line.dart';
+import 'package:enough_mail/src/imap/list_parser.dart';
+import 'package:enough_mail/src/util/client_base.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final serverInfo = ImapServerInfo(ConnectionInfo('localhost', 993, true));
+
+  Response<List<Mailbox>> _parseListResponse(ListParser parser, sourceData) {
+    var response = Response<List<Mailbox>>()..status = ResponseStatus.OK;
+    sourceData.forEach((details) => parser.parseUntagged(details, response));
+    return response;
+  }
+
+  test('List all mailboxes', () {
+    final lines = [
+      'LIST (\\Marked \\NoInferiors) "/" "inbox"',
+      'LIST () "/" "Fruit"',
+      'LIST () "/" "Fruit/Apple"',
+      'LIST () "/" "Fruit/Banana"',
+      'LIST () "/" "Tofu"',
+      'LIST () "/" "Vegetable"',
+      'LIST () "/" "Vegetable/Broccoli"',
+      'LIST () "/" "Vegetable/Corn"',
+    ];
+    var details = <ImapResponse>[];
+    lines.forEach(
+        (raw) => details.add(ImapResponse()..add(ImapResponseLine(raw))));
+    var parser = ListParser(serverInfo);
+    var response = _parseListResponse(parser, details);
+    var mboxes = parser.parse(null, response);
+    expect(mboxes.length, 8);
+    expect(mboxes[0].isInbox, true);
+    expect(mboxes[0].hasFlag(MailboxFlag.marked), true);
+    expect(mboxes[0].hasFlag(MailboxFlag.noInferior), true);
+    expect(mboxes[4].path, 'Tofu');
+    expect(mboxes[6].path, 'Vegetable/Broccoli');
+  });
+
+  test('List extended: SUBSCRIBED response', () {
+    final lines = [
+      r'LIST (\Marked \NoInferiors \Subscribed) "/" "inbox"',
+      r'LIST (\Subscribed) "/" "Fruit/Banana"',
+      r'LIST (\Subscribed \NonExistent) "/" "Fruit/Peach"',
+      r'LIST (\Subscribed) "/" "Vegetable"',
+      r'LIST (\Subscribed) "/" "Vegetable/Broccoli"',
+    ];
+    var details = <ImapResponse>[];
+    lines.forEach(
+        (raw) => details.add(ImapResponse()..add(ImapResponseLine(raw))));
+    var parser = ListParser(serverInfo, isExtended: true);
+    var response = _parseListResponse(parser, details);
+    var mboxes = parser.parse(null, response);
+    expect(mboxes.length, 5);
+    expect(mboxes[0].hasFlag(MailboxFlag.subscribed), true);
+    expect(mboxes[2].hasFlag(MailboxFlag.nonExistent), true);
+    expect(mboxes[4].path, 'Vegetable/Broccoli');
+  });
+
+  test('List extended: return CHILDREN response', () {
+    final lines = [
+      r'LIST (\Marked \NoInferiors) "/" "inbox"',
+      r'LIST (\HasChildren) "/" "Fruit"',
+      r'LIST (\HasNoChildren) "/" "Tofu"',
+      r'LIST (\HasChildren) "/" "Vegetable"',
+    ];
+    var details = <ImapResponse>[];
+    lines.forEach(
+        (raw) => details.add(ImapResponse()..add(ImapResponseLine(raw))));
+    var parser =
+        ListParser(serverInfo, isExtended: true, hasReturnOptions: true);
+    var response = _parseListResponse(parser, details);
+    var mboxes = parser.parse(null, response);
+    expect(mboxes.length, 4);
+    expect(mboxes[0].hasFlag(MailboxFlag.noInferior), true);
+    expect(mboxes[2].hasFlag(MailboxFlag.hasNoChildren), true);
+  });
+
+  test('List extended: REMOTE, return CHILDREN response', () {
+    final lines = [
+      r'LIST (\Marked \NoInferiors) "/" "inbox"',
+      r'LIST (\HasChildren) "/" "Fruit"',
+      r'LIST (\HasNoChildren) "/" "Tofu"',
+      r'LIST (\HasChildren) "/" "Vegetable"',
+      r'LIST (\Remote) "/" "Bread"',
+      r'LIST (\HasChildren \Remote) "/" "Meat"',
+    ];
+    var details = <ImapResponse>[];
+    lines.forEach(
+        (raw) => details.add(ImapResponse()..add(ImapResponseLine(raw))));
+    var parser =
+        ListParser(serverInfo, isExtended: true, hasReturnOptions: true);
+    var response = _parseListResponse(parser, details);
+    var mboxes = parser.parse(null, response);
+    expect(mboxes.length, 6);
+    expect(mboxes[4].hasFlag(MailboxFlag.remote), true);
+    expect(mboxes[5].hasFlag(MailboxFlag.remote), true);
+    expect(mboxes[5].hasFlag(MailboxFlag.hasChildren), true);
+  });
+
+  test('List extended: SUBSCRIBED RECURSIVEMATCH response', () {
+    final lines = [
+      r'LIST () "/" "Foo" ("CHILDINFO" ("SUBSCRIBED"))',
+    ];
+    var details = <ImapResponse>[];
+    lines.forEach(
+        (raw) => details.add(ImapResponse()..add(ImapResponseLine(raw))));
+    var parser = ListParser(serverInfo, isExtended: true);
+    var response = _parseListResponse(parser, details);
+    var mboxes = parser.parse(null, response);
+    expect(mboxes.length, 1);
+    expect(mboxes[0].name, 'Foo');
+    expect(mboxes[0].extendedData, contains('CHILDINFO'));
+    expect(mboxes[0].extendedData['CHILDINFO'], contains('SUBSCRIBED'));
+  });
+}


### PR DESCRIPTION
Add an implementation of:
- [rfc5258: LIST command extensions](https://tools.ietf.org/html/rfc5258)
- [rfc5819: return STATUS in extended lists](https://tools.ietf.org/html/rfc5819)
- [rfc6154: SPECIAL-USE mailboxes](https://tools.ietf.org/html/rfc6154)

This enable us to send an IMAP command like:
```
LIST (SUBSCRIBED) "" "%" RETURN (SPECIAL-USE STATUS (MESSAGES UNSEEN))
```
for a list of subscribed mailboxes with special-use flags and stats.