### PR TITLE
Codec | Date values (day, month, hour, second) should pad left 0

### DIFF
--- a/lib/codecs/date_codec.dart
+++ b/lib/codecs/date_codec.dart
@@ -314,17 +314,17 @@ Date and time values occur in several header fields.  This section
     final buffer = StringBuffer();
     buffer.write(_weekdays[dateTime.weekday - 1]);
     buffer.write(', ');
-    buffer.write(dateTime.day);
+    buffer.write(dateTime.day.toString().padLeft(2, '0'));
     buffer.write(' ');
     buffer.write(_months[dateTime.month - 1]);
     buffer.write(' ');
     buffer.write(dateTime.year);
     buffer.write(' ');
-    buffer.write(dateTime.hour);
+    buffer.write(dateTime.hour.toString().padLeft(2, '0'));
     buffer.write(':');
-    buffer.write(dateTime.minute);
+    buffer.write(dateTime.minute.toString().padLeft(2, '0'));
     buffer.write(':');
-    buffer.write(dateTime.second);
+    buffer.write(dateTime.second.toString().padLeft(2, '0'));
     buffer.write(' ');
     if (dateTime.timeZoneOffset.inMinutes > 0) {
       buffer.write('+');


### PR DESCRIPTION
Hello again!

I checked through some mails sent and detected some issues that we didn't track before.
The date. We got a bad spam score, because the date values had no 0s prepended.

Compare:
<img width="400" src="https://user-images.githubusercontent.com/12692409/114158917-86d6dd00-9925-11eb-96f4-34ba3ab6acb1.png" />

It seems that in this case the server even miscalculated sent/receive date.
I fixed it in DateCodec for us.

If there are any other occurrences in code, consider padding them.

The code just wrote `date.hour` as it is.
I just placed a `date.hour.toString().padLeft(2, '0)`

Alternatives:  
`'${date.hour}'.padLeft(2, '0')`  
`date.hour < 10 ? '0${date.hour}' : date.hour`  

Now I got:  
`Date: Fri, 09 Apr 2021 11:04:47 +0200`

Resulting in:  
```
X-HE-Spam-Score: 0.0
X-HE-Spam-Report: Content analysis details:   (0.0 points)
```

Another question: Did my last changes to the performance and dkim land in pub.dev ?
I am not sure if I can put my dependency on there again or if I should leave it on my fork.