### PR TITLE
Handling '.TEXT' and '.HEADER' body parts.

### DIFF
--- a/lib/src/imap/fetch_parser.dart
+++ b/lib/src/imap/fetch_parser.dart
@@ -186,7 +186,7 @@ class FetchParser extends ResponseParser<FetchImapResult> {
       }
       part.parse();
       //print('$fetchId: results in [${imapValue.value}]');
-      message.setPart(fetchId, part);
+      message.setPart(fetchId.replaceFirst('.HEADER', ''), part);
     }
   }
 


### PR DESCRIPTION
Hi, this patch contains some work I've done related to the issue #142.
It's tailored to my use-case, so not much was changed from the original code, and it's really short.
These are the changes provided:
- When fetching an `.HEADER` part, remaps it to the entire part id (ex: 4.2.HEADER to 4.2). The `.TEXT` and `.MIME` parts id are unchanged;
- Prioritizes the bodystructure in `findContentInfo()`, returning a set of ids suitable for the direct part fetching, avoiding an issue with multipart rfc822 (I'm referring to the 4.2.TEXT part of the example) unless the provided flag is cleared.

I've also noticed that using the MIME designator on a rfc822 part, for example 4.2.MIME, it's possible to fetch the headers of the mime part containing the message, whilst HEADER returns the contained message headers.