### PR TITLE
Split message/rfc822 nested MimeParts correctly.

### DIFF
--- a/lib/src/util/byte_utils.dart
+++ b/lib/src/util/byte_utils.dart
@@ -1,0 +1,23 @@
+class ByteUtils {
+  /// Finds a [sequence] of bytes into a [pool], returns the starting position or -1 if not found.
+  static int findSequence(final List<int> pool, final List<int> sequence) {
+    // The pool size is reduced by the sequence length to avoid the eventual overflow
+    final dataSize = pool.length - sequence.length;
+    final needleSize = sequence.length;
+    var result = -1;
+    for (var pos = 0; pos < dataSize; pos++) {
+      var matchFound = true;
+      for (var j = 0; j < needleSize; j++) {
+        if (pool[pos + j] != sequence[j]) {
+          matchFound = false;
+          break;
+        }
+      }
+      if (matchFound) {
+        result = pos;
+        break;
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
Hi,
with this patch the `_parseContent` methods can found the boundary definitions in inline and attached rfc822 parts.
The result is an almost complete division of the mime structure, comparable to that of the bodystructure, and allow to address a child part directly if needed.