### PR TITLE
Fix header and subject encoding.

### DIFF
--- a/lib/codecs/mail_codec.dart
+++ b/lib/codecs/mail_codec.dart
@@ -9,6 +9,8 @@ import 'package:enough_mail/src/util/ascii_runes.dart';
 import 'quoted_printable_mail_codec.dart';
 import 'base64_mail_codec.dart';
 
+enum HeaderEncoding { Q, B, none }
+
 /// Encodes and decodes base-64 and quoted printable encoded texts
 /// Compare https://tools.ietf.org/html/rfc2045#page-19
 /// and https://tools.ietf.org/html/rfc2045#page-23 for details
@@ -184,6 +186,18 @@ abstract class MailCodec {
       input = input.substring(match.end);
     }
     buffer.write(input);
+  }
+
+  static HeaderEncoding detectHeaderEncoding(String value) {
+    var match = _encodingExpression.firstMatch(value);
+    if (match == null) {
+      return HeaderEncoding.none;
+    }
+    var group = match.group(0);
+    if (group?.contains('?B?') ?? false) {
+      return HeaderEncoding.B;
+    }
+    return HeaderEncoding.Q;
   }
 
   static Uint8List decodeBinary(String text, String? transferEncoding) {

--- a/lib/codecs/quoted_printable_mail_codec.dart
+++ b/lib/codecs/quoted_printable_mail_codec.dart
@@ -56,12 +56,13 @@ class QuotedPrintableMailCodec extends MailCodec {
   /// Encodes the header text in Q encoding only if required.
   /// Compare https://tools.ietf.org/html/rfc2047#section-4.2 for details.
   /// [text] specifies the text to be encoded.
+  /// [nameLength] the length of the header name, for calculating the wrapping point.
   /// [codec] the optional codec, which defaults to utf8.
   /// Set the optional [fromStart] to true in case the encoding should  start at the beginning of the text and not in the middle.
   @override
-  String encodeHeader(String text,
-      {Codec codec = utf8, bool fromStart = false}) {
-    var runes = List.from(text.runes);
+  String encodeHeader(final String text,
+      {int nameLength = 0, Codec codec = utf8, bool fromStart = false}) {
+    var runes = List.from(text.runes, growable: false);
     var numberOfRunesAbove7Bit = 0;
     var startIndex = -1;
     var endIndex = -1;
@@ -82,10 +83,23 @@ class QuotedPrintableMailCodec extends MailCodec {
     if (numberOfRunesAbove7Bit == 0) {
       return text;
     } else {
+      // TODO Set the correct encoding
+      final qpWordHead = '=?utf8?Q?';
+      final qpWordTail = '?=';
+      final qpWordDelimSize = qpWordHead.length + qpWordTail.length;
       if (fromStart) {
         startIndex = 0;
         endIndex = text.length - 1;
       }
+      // Available space for the current encoded word
+      var qpWordSize = MailConventions.encodedWordMaxLength -
+          qpWordDelimSize -
+          startIndex -
+          (nameLength + 2);
+      // Counts the characters of the current encoded word
+      var wordCounter = 0;
+      // True when reached the end of the current word available space
+      var isWordSplit = false;
       var buffer = StringBuffer();
       for (var runeIndex = 0; runeIndex < runeCount; runeIndex++) {
         var rune = runes[runeIndex];
@@ -93,20 +107,55 @@ class QuotedPrintableMailCodec extends MailCodec {
           buffer.writeCharCode(rune);
           continue;
         }
-        if (runeIndex == startIndex) {
-          buffer.write('=?utf8?Q?');
+        if (runeIndex == startIndex || isWordSplit) {
+          // Adds the line terminator
+          if (isWordSplit) {
+            buffer
+              ..write(qpWordTail)
+              // NOTE Per specification, a CRLF should be inserted here,
+              // but the folding occurs on the rendering function.
+              // Here we leave only the WSP marker to separate each q-encode word.
+              // ..writeCharCode(AsciiRunes.runeCarriageReturn)
+              // ..writeCharCode(AsciiRunes.runeLineFeed)
+              // Assumes per default a single leading space for header folding
+              ..writeCharCode(AsciiRunes.runeSpace);
+            // Resets the split flag
+            isWordSplit = false;
+            // Calculates the new encoded word size
+            qpWordSize =
+                MailConventions.encodedWordMaxLength - qpWordDelimSize - 1;
+          }
+          buffer.write(qpWordHead);
         }
         if ((rune > AsciiRunes.runeSpace && rune <= 60) ||
             (rune == 62) ||
             (rune > 63 && rune <= 126 && rune != AsciiRunes.runeUnderline)) {
-          buffer.writeCharCode(rune);
+          wordCounter++;
+          isWordSplit = wordCounter > qpWordSize;
+          if (!isWordSplit) {
+            buffer.writeCharCode(rune);
+          }
         } else if (rune == AsciiRunes.runeSpace) {
-          buffer.write('_');
+          wordCounter++;
+          isWordSplit = wordCounter > qpWordSize;
+          if (!isWordSplit) {
+            buffer.write('_');
+          }
         } else {
-          _writeQuotedPrintable(rune, buffer, codec);
+          // _writeQuotedPrintable(rune, buffer, codec);
+          final quoted = _encodeQuotedPrintableChar(rune, codec);
+          wordCounter += quoted.length;
+          isWordSplit = wordCounter > qpWordSize;
+          if (!isWordSplit) {
+            buffer.write(quoted);
+          }
+        }
+        if (isWordSplit) {
+          wordCounter = 0;
+          runeIndex--;
         }
         if (runeIndex == endIndex) {
-          buffer.write('?=');
+          buffer.write(qpWordTail);
         }
       }
       return buffer.toString();
@@ -141,8 +190,13 @@ class QuotedPrintableMailCodec extends MailCodec {
             charCodes.add(charCode);
           }
 
-          var decoded = codec.decode(charCodes);
-          buffer.write(decoded);
+          try {
+            var decoded = codec.decode(charCodes);
+            buffer.write(decoded);
+          } on FormatException catch (err) {
+            print('unable to decode quptedPrintable buffer: ${err.message}');
+            buffer.write(String.fromCharCodes(charCodes));
+          }
         }
         i += 2;
       } else if (isHeader && char == '_') {
@@ -173,6 +227,15 @@ class QuotedPrintableMailCodec extends MailCodec {
       buffer.write(paddedHexValue);
     }
     return buffer.length - lengthBefore;
+  }
+
+  /// Encodes a single rune of a quoted printable word.
+  ///
+  /// Uses [_writeQuotedPrintable] internally.
+  String _encodeQuotedPrintableChar(int rune, Codec codec) {
+    var buffer = StringBuffer();
+    _writeQuotedPrintable(rune, buffer, codec);
+    return buffer.toString();
   }
 
   @override

--- a/lib/mail_conventions.dart
+++ b/lib/mail_conventions.dart
@@ -3,6 +3,14 @@ class MailConventions {
   /// The maximum length of a text email should not be longer than 76 characters.
   static const int textLineMaxLength = 76;
 
+  /// The maximum length of an encoded word in header space sould not be longer than 75 characters.
+  ///
+  /// That includes the charset, encoding, delimiters and actual data, compare https://tools.ietf.org/html/rfc2047#section-2
+  static const int encodedWordMaxLength = 75;
+
+  /// The maximum length of a line in an Internet Message Format, compare https://tools.ietf.org/html/rfc5322#section-2.1.1
+  static const int messageLineMaxLength = 998;
+
   static const String defaultReplyAbbreviation = 'Re';
   static const String defaultReplyHeaderTemplate = 'On <date> <from> wrote:';
   static const String defaultForwardAbbreviation = 'Fwd';

--- a/lib/mime_message.dart
+++ b/lib/mime_message.dart
@@ -81,19 +81,41 @@ class MimePart {
     return headers?.where((h) => h.lowerCaseName == name);
   }
 
-  /// Adds a header with the specified [name] and [value].
-  void addHeader(String name, String? value) {
+  /// Adds a header with the specified [name], [value] and optional [encoding].
+  void addHeader(String name, String? value,
+      [HeaderEncoding encoding = HeaderEncoding.none]) {
     headers ??= <Header>[];
-    final header = Header(name, value);
+    var localValue = value;
+    if (value != null) {
+      if (encoding == HeaderEncoding.Q) {
+        localValue = MailCodec.quotedPrintable
+            .encodeHeader(value, nameLength: name.length);
+      } else if (encoding == HeaderEncoding.B) {
+        localValue =
+            MailCodec.base64.encodeHeader(value, nameLength: name.length);
+      }
+    }
+    final header = Header(name, localValue, encoding);
     headers!.add(header);
   }
 
-  /// Sets a header with the specified [name] and [value], replacing any existing header with the same [name].
-  void setHeader(String name, String? value) {
+  /// Sets a header with the specified [name], [value] and optional [encoding], replacing any existing header with the same [name].
+  void setHeader(String name, String? value,
+      [HeaderEncoding encoding = HeaderEncoding.none]) {
     headers ??= <Header>[];
     final lowerCaseName = name.toLowerCase();
     headers!.removeWhere((h) => h.lowerCaseName == lowerCaseName);
-    headers!.add(Header(name, value));
+    var localValue = value;
+    if (value != null) {
+      if (encoding == HeaderEncoding.Q) {
+        localValue = MailCodec.quotedPrintable
+            .encodeHeader(value, nameLength: name.length);
+      } else if (encoding == HeaderEncoding.B) {
+        localValue =
+            MailCodec.base64.encodeHeader(value, nameLength: name.length);
+      }
+    }
+    headers!.add(Header(name, localValue, encoding));
   }
 
   void insertPart(MimePart part) {
@@ -920,9 +942,10 @@ class MimeMessage extends MimePart {
 class Header {
   final String name;
   final String? value;
+  final HeaderEncoding encoding;
   String? lowerCaseName;
 
-  Header(this.name, this.value) {
+  Header(this.name, this.value, [this.encoding = HeaderEncoding.none]) {
     lowerCaseName = name.toLowerCase();
   }
 

--- a/lib/src/imap/parser_helper.dart
+++ b/lib/src/imap/parser_helper.dart
@@ -1,3 +1,4 @@
+import 'package:enough_mail/codecs/mail_codec.dart';
 import 'package:enough_mail/src/util/word.dart';
 
 import '../../mime_message.dart';
@@ -174,7 +175,7 @@ class HeaderParseResult {
   int? bodyStartIndex;
 
   void add(String name, String value) {
-    final header = Header(name, value);
+    final header = Header(name, value, MailCodec.detectHeaderEncoding(value));
     headersList.add(header);
   }
 }

--- a/test/codecs/folding_test.dart
+++ b/test/codecs/folding_test.dart
@@ -1,0 +1,71 @@
+import 'package:enough_mail/enough_mail.dart';
+import 'package:enough_mail/message_builder.dart';
+import 'package:enough_mail/mime_message.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('folding test qp-encode full', () {
+    final subject =
+        'àáèéìíòóùúỳýäëïöüÿæßñµ¢łŁ àáèéìíòóùúỳýäëïöüÿæßñµ¢łŁasciiàáèéìíòóùúỳýäëïöüÿæßñµ¢łŁ';
+    var message = _buildTestMessage(subject);
+    expect(message!.decodeSubject(), subject);
+    var buffer = StringBuffer();
+    message.getHeader('subject')!.first.render(buffer);
+    var output = buffer.toString().split(RegExp(r'\r\n\s+'));
+    expect(output.length, greaterThan(1));
+    expect(output, everyElement(HasLength(lessThanOrEqualTo(76))));
+  });
+
+  test('folding test qp-encode greek', () {
+    final subject = 'Λορεμ ιπσθμ δολορ σιτ αμετ, φερρι φαβθλασ οπορτεατ σεα ει';
+    var message = _buildTestMessage(subject);
+    expect(message!.decodeSubject(), subject);
+    var buffer = StringBuffer();
+    message.getHeader('subject')!.first.render(buffer);
+    var output = buffer.toString().split(RegExp(r'\r\n\s+'));
+    expect(output.length, greaterThan(1));
+    expect(output, everyElement(HasLength(lessThanOrEqualTo(76))));
+  });
+
+  test('folding test mixed qp-encode', () {
+    final subject =
+        'Quick: do you have a plan to become proactive àáèéìíòóùúỳýäëïöüÿæßñµ¢łŁ. '
+        'We understand that if you integrate intuitively then you may also mesh iteravely.';
+    var message = _buildTestMessage(subject);
+    expect(message!.decodeSubject(), subject);
+    var buffer = StringBuffer();
+    message.getHeader('subject')!.first.render(buffer);
+    var output = buffer.toString().split(RegExp(r'\r\n\s+'));
+    expect(output.length, greaterThan(1));
+    expect(output, everyElement(HasLength(lessThanOrEqualTo(76))));
+  });
+
+  test('folding test b-encode', () {
+    final subject =
+        'Quick: do you have a plan to become proactive àáèéìíòóùúỳýäëïöüÿæßñµ¢łŁ. '
+        'We understand that if you integrate intuitively then you may also mesh iteravely.';
+    var message = _buildTestMessage(subject, HeaderEncoding.B);
+    expect(message!.decodeSubject(), subject);
+    var buffer = StringBuffer();
+    message.getHeader('subject')!.first.render(buffer);
+    var output = buffer.toString().split(RegExp(r'\r\n\s+'));
+    expect(output.length, greaterThan(1));
+    expect(output, everyElement(HasLength(lessThanOrEqualTo(76))));
+  });
+}
+
+MimeMessage? _buildTestMessage(String subject,
+        [HeaderEncoding encoding = HeaderEncoding.Q]) =>
+    MessageBuilder.buildSimpleTextMessage(
+      MailAddress('mittente', 'test@example.com'),
+      [MailAddress('destinatario', 'recipient@example.com')],
+      'This is a short text',
+      subject: subject,
+      subjectEncoding: encoding,
+    );
+
+class HasLength extends CustomMatcher {
+  HasLength(matcher) : super('String which length than is', 'length', matcher);
+  @override
+  int featureValueOf(actual) => (actual as String).length;
+}

--- a/test/codecs/quoted_printable_mail_codec_test.dart
+++ b/test/codecs/quoted_printable_mail_codec_test.dart
@@ -83,7 +83,7 @@ void main() {
           'Hello Wörld. This is a long text without linebreak and this contains the formula c^2=a^2+b^2.');
     });
 
-    test('encodeText.quoted-printable \r\n line breaks', () {
+    test(r'encodeText.quoted-printable \r\n line breaks', () {
       var input =
           'Hello Wörld.\r\nThis is a long text with\r\na linebreak and this contains the formula c^2=a^2+b^2.';
       expect(MailCodec.quotedPrintable.encodeText(input),
@@ -95,7 +95,7 @@ void main() {
           input);
     });
 
-    test('encodeText.quoted-printable \n line breaks', () {
+    test(r'encodeText.quoted-printable \n line breaks', () {
       var input =
           'Hello Wörld.\nThis is a long text with\na linebreak and this contains the formula c^2=a^2+b^2.';
       expect(MailCodec.quotedPrintable.encodeText(input),


### PR DESCRIPTION
Hi,
this patch resolves an issue with the encoded headers that are wrapped incorrectly, adds the explicit encoding of the message subject and the ability to choose between the types of encoding available for the headers values.

In detail, the issue pertains to the qp and base64 encoding of the headers (almost everytime the message subject) that doesn't wrap correctly. For the qp one, having a long sequence of extended characters the max length of the encoded word isn't respected and when sending, the encoded header value is wrapped sometimes in between the encoded triplets:
`=C3=BA=E1=B<wraps here>B=B3=C3` instead of `=C3=BA=E1=BB=<wraps here>B3=C3`
and doesn't account the header name length in the first line.

With the remaining patches, we can choose what type of encoding (either qp or base64 or none) should be used for the message subject (defaulting to QP) as the spec indicates also a base64 one. That's can be a possible breaking change for the `encoding` parameter (changes from boolean to enum value).

Lastlty, the encoding assumes per default an utf8 string as input, but shouldn't be a problem for a dart/flutter app.

Regards.