### PR TITLE
Fix running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this dependency your pubspec.yaml file:
 
 ```
 dependencies:
-  enough_mail: ^1.3.4
+  enough_mail: ^1.3.6
 ```
 The latest version or `enough_mail` is [![enough_mail version](https://img.shields.io/pub/v/enough_mail.svg)](https://pub.dartlang.org/packages/enough_mail).
 
@@ -289,7 +289,7 @@ Transfer encodings:
 * Compare [issues](https://github.com/Enough-Software/enough_mail/issues)
 
 ### Develop and Contribute
-* To start check out the package and then run `pub run test` to run all tests.
+* To start check out the package and then run `dart run test` to run all tests.
 * Public facing library classes are in *lib*, *lib/imap* and *lib/smtp*. 
 * Private classes are in *lib/src*.
 * Test cases are in *test*.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,3 +25,4 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.20.1
+  pedantic: ^1.11.1


### PR DESCRIPTION
This PR fixes running tests by adding `pedantic` as a dev dependency, as the tests would not run locally otherwise on a machine that doesn't have the deprecated library installed globally. Alternatively, the README would require a passage mentioning to install `pedantic` as a global dependency. The library should probably be replaced anyway, given its deprecation status, but that is beyond the scope of this PR.

Also includes an edit of the README replacing `pub run test` with `dart run test` in order to get rid of the deprecation warning `The top level 'pub' command is deprecated.`.