### PR TITLE
Fix timezones west of Greenwich

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this dependency your pubspec.yaml file:
 
 ```
 dependencies:
-  enough_mail: ^1.3.4
+  enough_mail: ^1.3.6
 ```
 The latest version or `enough_mail` is [![enough_mail version](https://img.shields.io/pub/v/enough_mail.svg)](https://pub.dartlang.org/packages/enough_mail).
 
@@ -289,7 +289,7 @@ Transfer encodings:
 * Compare [issues](https://github.com/Enough-Software/enough_mail/issues)
 
 ### Develop and Contribute
-* To start check out the package and then run `pub run test` to run all tests.
+* To start check out the package and then run `dart run test` to run all tests.
 * Public facing library classes are in *lib*, *lib/imap* and *lib/smtp*. 
 * Private classes are in *lib/src*.
 * Test cases are in *test*.

--- a/lib/src/codecs/date_codec.dart
+++ b/lib/src/codecs/date_codec.dart
@@ -340,7 +340,7 @@ Date and time values occur in several header fields.  This section
     if (hours < 10 && hours > -10) {
       buffer.write('0');
     }
-    buffer.write(hours);
+    buffer.write(hours.abs());
     final minutes = dateTime.timeZoneOffset.inMinutes -
         (dateTime.timeZoneOffset.inHours * 60);
     if (minutes == 0) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,3 +25,4 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.20.1
+  pedantic: ^1.11.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,5 +24,6 @@ dependencies:
 
 dev_dependencies:
   lints: ^1.0.1
-  test: ^1.20.1
   pedantic: ^1.11.1
+  test: ^1.20.1
+  timezone: ^0.8.0

--- a/test/codecs/date_codec_test.dart
+++ b/test/codecs/date_codec_test.dart
@@ -1,7 +1,25 @@
 import 'package:enough_mail/src/codecs/date_codec.dart';
 import 'package:test/test.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 void main() {
+  tz.initializeTimeZones();
+
+  group('encode dates', () {
+    test('encodeDate for UTC DateTime', () {
+      expect(DateCodec.encodeDate(DateTime.utc(2022, 1, 7, 22, 18)),
+          'Fri, 07 Jan 2022 22:18:00 -0000');
+    });
+    test('encodeDate for DateTime east of Greenwich', () {
+      expect(
+        DateCodec.encodeDate(
+            tz.TZDateTime(tz.getLocation('Europe/Berlin'), 2022, 1, 7, 22, 18)),
+        'Fri, 07 Jan 2022 22:18:00 +0100',
+      );
+    });
+  });
+
   group('decode dates', () {
     test('decodeDate simple', () {
       expect(DateCodec.decodeDate('11 Feb 2020 22:45 +0000'),

--- a/test/codecs/date_codec_test.dart
+++ b/test/codecs/date_codec_test.dart
@@ -18,6 +18,13 @@ void main() {
         'Fri, 07 Jan 2022 22:18:00 +0100',
       );
     });
+    test('encodeDate for DateTime west of Greenwich', () {
+      expect(
+        DateCodec.encodeDate(tz.TZDateTime(
+            tz.getLocation('America/Panama'), 2022, 1, 7, 22, 18)),
+        'Fri, 07 Jan 2022 22:18:00 -0500',
+      );
+    });
   });
 
   group('decode dates', () {


### PR DESCRIPTION
This PR fixes date encoding for timezone ahead of UTC. Previously, this did not work correctly. For example, a DateTime in Panama would have been encoded as `Fri, 07 Jan 2022 22:18:00 -0-500` instead of `Fri, 07 Jan 2022 22:18:00 -0500` as expected. The fix itself was simple, all that was required was using the [absolute value](Fri, 07 Jan 2022 22:18:00 -0-500) of the hours of the offset.

The PR adds the `timezone` lib as a test dependency so that DateTime instances with a timezone can be constructed. Please let me know if this is acceptable or if there is a better approach that does not require additional dependencies. The PR also includes the commits from #180 that fixed running tests on my machine.  