### PR TITLE
Fix RangeError when a Mailbox name contains a "("

### DIFF
--- a/lib/src/private/imap/status_parser.dart
+++ b/lib/src/private/imap/status_parser.dart
@@ -6,10 +6,12 @@ import 'response_parser.dart';
 /// Parses status responses
 class StatusParser extends ResponseParser<Mailbox> {
   /// Creates a new parser
-  StatusParser(this.box);
+  StatusParser(this.box) : _regex = RegExp(r'(STATUS "[^"]+?" )(.*)');
 
   /// The current mailbox
   Mailbox box;
+
+  final RegExp _regex;
 
   @override
   Mailbox? parse(ImapResponse imapResponse, Response<Mailbox> response) =>
@@ -19,7 +21,7 @@ class StatusParser extends ResponseParser<Mailbox> {
   bool parseUntagged(ImapResponse imapResponse, Response<Mailbox>? response) {
     final details = imapResponse.parseText;
     if (details.startsWith('STATUS ')) {
-      final startIndex = details.indexOf('(');
+      final startIndex = _findStartIndex(details);
       if (startIndex == -1) {
         return false;
       }
@@ -55,5 +57,13 @@ class StatusParser extends ResponseParser<Mailbox> {
     } else {
       return super.parseUntagged(imapResponse, response);
     }
+  }
+
+  int _findStartIndex(String details) {
+    final matches = _regex.allMatches(details);
+    if (matches.isNotEmpty && matches.first.groupCount == 2) {
+      return matches.first.group(1)!.length;
+    }
+    return -1;
   }
 }

--- a/test/src/imap/status_parser_test.dart
+++ b/test/src/imap/status_parser_test.dart
@@ -41,4 +41,21 @@ void main() {
     expect(box.uidValidity, 2222);
     expect(box.uidNext, 876);
   });
+
+  test('Status of Mailbox with name containing brackets', () {
+    const responseText =
+        'STATUS "upper level.Funny folder (with brackets)" (MESSAGES 2)';
+    final details = ImapResponse()..add(ImapResponseLine(responseText));
+    final box = Mailbox(
+      encodedName: 'Funny folder (with brackets)',
+      encodedPath: 'upper level.Funny folder (with brackets)',
+      flags: [MailboxFlag.junk],
+      pathSeparator: '.',
+    );
+    final parser = StatusParser(box);
+    final response = Response<Mailbox>()..status = ResponseStatus.ok;
+    final processed = parser.parseUntagged(details, response);
+    expect(processed, true);
+    expect(box.messagesExists, 2);
+  });
 }


### PR DESCRIPTION
The StatusParser triggers a RangeError when the Mailbox's name contains a "(", e.g. "name with (brackets)".

- Added implementation in status_parser.dart
- Added test in status_parser_test.dart