### PR TITLE
Prefer the Mailbox pathSeparator over the MailAccount pathSeparator

### DIFF
--- a/lib/src/mail/mail_client.dart
+++ b/lib/src/mail/mail_client.dart
@@ -372,7 +372,9 @@ class MailClient {
     List<Mailbox>? firstBoxes;
     firstBoxes = sortMailboxes(order, mailboxes, keepRemaining: false);
     final boxes = [...mailboxes]..sort((b1, b2) => b1.path.compareTo(b2.path));
-    final separator = _account.incoming.pathSeparator;
+    final separator = (mailboxes.isNotEmpty)
+        ? mailboxes.first.pathSeparator
+        : _account.incoming.pathSeparator;
     final tree = Tree<Mailbox?>(null)
       ..populateFromList(
         boxes,


### PR DESCRIPTION
#226 

As a proposal prefer the pathSeparator of the first Mailbox. The else path is quite useless because for an empty MailBox list the pathSeparator has no meaning.