### PR TITLE
fix: trim lines read after decoding

### DIFF
--- a/lib/src/private/util/uint8_list_reader.dart
+++ b/lib/src/private/util/uint8_list_reader.dart
@@ -30,7 +30,7 @@ class Uint8ListReader {
       return null;
     }
     final data = _builder.takeFirst(pos + 1);
-    final line = _utf8decoder.convert(data, 0, pos - 1);
+    final line = _utf8decoder.convert(data, 0, pos - 1).trimLeft();
 
     return line;
   }
@@ -42,7 +42,7 @@ class Uint8ListReader {
       return null;
     }
     final data = _builder.takeFirst(pos + 1);
-    final text = _utf8decoder.convert(data);
+    final text = _utf8decoder.convert(data).trimLeft();
 
     return text.split('\r\n')..removeLast();
   }


### PR DESCRIPTION
Some POP servers send replies like:
(LF)+OK(CRLF)
...

Which causes a format exception when parsing the reply. Fix this by trimming lines.