### PR TITLE
pub upgrade to bring in intl 0.20.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   encrypt: ^5.0.0
   enough_convert: ^1.5.0
   event_bus: ^2.0.0
-  intl: ^0.19.0
+  intl: ^0.20.2
   json_annotation: ^4.8.0
   pointycastle: ^3.6.0
   synchronized: ^3.1.0
@@ -34,8 +34,8 @@ dependency_overrides:
 dev_dependencies:
   build_runner: ^2.3.0
   dart_code_metrics: 5.7.6
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
   json_serializable: ^6.3.0
-  lints: ^4.0.0
+  lints: ^6.0.0
   test: ^1.20.1
-  timezone: ^0.9.0
+  timezone: ^0.10.1


### PR DESCRIPTION
`flutter pub upgrade`
followed by:
`flutter pub upgrade --major-versions`

All tests pass.

Intent is to upgrade to intl 0.20.2, supporting Flutter 3.32.

Fixes #252 