### PR TITLE
feat: add SecurityContext support for mTLS (mutual TLS)

### DIFF
--- a/lib/src/imap/imap_client.dart
+++ b/lib/src/imap/imap_client.dart
@@ -236,6 +236,9 @@ class ImapClient extends ClientBase {
   /// (or let the user decide) whether to accept the connection or not.
   /// The handler should return `true` to continue the [SecureSocket]
   /// connection.
+  ///
+  /// [securityContext] is an optional [SecurityContext] for mTLS
+  /// (mutual TLS / client certificate authentication).
   ImapClient({
     EventBus? bus,
     bool isLogEnabled = false,
@@ -243,11 +246,13 @@ class ImapClient extends ClientBase {
     this.defaultWriteTimeout,
     this.defaultResponseTimeout,
     bool Function(X509Certificate)? onBadCertificate,
+    SecurityContext? securityContext,
   })  : _eventBus = bus ?? EventBus(),
         super(
           isLogEnabled: isLogEnabled,
           logName: logName,
           onBadCertificate: onBadCertificate,
+          securityContext: securityContext,
         ) {
     _imapResponseReader = ImapResponseReader(onServerResponse);
   }

--- a/lib/src/private/util/client_base.dart
+++ b/lib/src/private/util/client_base.dart
@@ -29,10 +29,16 @@ abstract class ClientBase {
   /// The handler receives the [X509Certificate], and can inspect it and decide
   /// (or let the user decide) whether to accept the connection or not.
   /// The handler should return true to continue the [SecureSocket] connection.
+  ///
+  /// [securityContext] is an optional security context for mTLS
+  /// (mutual TLS / client certificate authentication).
+  /// Create a [SecurityContext] with `useCertificateChain()` and
+  /// `usePrivateKey()` to enable client certificate authentication.
   ClientBase({
     this.isLogEnabled = false,
     this.logName,
     this.onBadCertificate,
+    this.securityContext,
   });
 
   /// Initial for a client log output
@@ -76,6 +82,12 @@ abstract class ClientBase {
   /// The handler should return true to continue the [SecureSocket] connection.
   final bool Function(X509Certificate)? onBadCertificate;
 
+  /// Optional [SecurityContext] for mTLS (mutual TLS).
+  ///
+  /// When set, it is passed to [SecureSocket.connect] and
+  /// [SecureSocket.secure] to enable client certificate authentication.
+  final SecurityContext? securityContext;
+
   /// Is called when data is received
   void onDataReceived(Uint8List data);
 
@@ -112,6 +124,7 @@ abstract class ClientBase {
             host,
             port,
             onBadCertificate: onBadCertificate,
+            context: securityContext,
           ).timeout(timeout)
         : await Socket.connect(host, port).timeout(timeout);
     _greetingsCompleter = Completer<ConnectionInfo>();
@@ -177,7 +190,11 @@ abstract class ClientBase {
   /// Upgrades the current connection to a secure socket
   Future<void> upgradeToSslSocket() async {
     _socketStreamSubscription.pause();
-    final secureSocket = await SecureSocket.secure(_socket);
+    final secureSocket = await SecureSocket.secure(
+      _socket,
+      context: securityContext,
+      onBadCertificate: onBadCertificate,
+    );
     logApp('now using secure connection.');
     await _socketStreamSubscription.cancel();
     isSocketClosingExpected = true;

--- a/lib/src/smtp/smtp_client.dart
+++ b/lib/src/smtp/smtp_client.dart
@@ -103,18 +103,23 @@ class SmtpClient extends ClientBase {
   /// The handler receives the [X509Certificate], and can inspect it and
   /// decide (or let the user decide) whether to accept the connection or not.
   /// The handler should return true to continue the [SecureSocket] connection.
+  ///
+  /// [securityContext] is an optional [SecurityContext] for mTLS
+  /// (mutual TLS / client certificate authentication).
   SmtpClient(
     String clientDomain, {
     EventBus? bus,
     bool isLogEnabled = false,
     String? logName,
     bool Function(X509Certificate)? onBadCertificate,
+    SecurityContext? securityContext,
   })  : _eventBus = bus ?? EventBus(),
         _clientDomain = clientDomain,
         super(
           isLogEnabled: isLogEnabled,
           logName: logName,
           onBadCertificate: onBadCertificate,
+          securityContext: securityContext,
         );
 
   /// Information about the SMTP service


### PR DESCRIPTION
## Summary

Add an optional `securityContext` parameter to `ClientBase`, `ImapClient`, and `SmtpClient` to enable **mutual TLS (mTLS) / client certificate authentication**.

This is needed for mail servers that require client certificates for authentication (e.g., HAProxy with `verify required`). Currently there is no way to pass a `SecurityContext` to the underlying `SecureSocket.connect()` call.

## Changes

- **`ClientBase`**: new optional `SecurityContext? securityContext` field, passed to `SecureSocket.connect()` and `SecureSocket.secure()`
  - Also fixes a bug: `upgradeToSslSocket()` was not passing `onBadCertificate` to `SecureSocket.secure()`
- **`ImapClient`**: forward `securityContext` to `ClientBase` super constructor
- **`SmtpClient`**: forward `securityContext` to `ClientBase` super constructor

## Usage

```dart
final context = SecurityContext()
  ..useCertificateChainBytes(utf8.encode(clientCertPem))
  ..usePrivateKeyBytes(utf8.encode(clientKeyPem));

final imapClient = ImapClient(
  isLogEnabled: true,
  onBadCertificate: (_) => true,
  securityContext: context,
);
await imapClient.connectToServer('mail.example.com', 993);
```

## Backwards Compatibility

The parameter is optional and defaults to `null`. Existing code is **completely unaffected** — no breaking changes.

## Motivation

We run a mail server with strict mTLS enforcement (HAProxy `verify required`). Without this change, we had to maintain a local fork of `enough_mail` just for these ~20 lines. This PR eliminates the need for that fork.