### PR TITLE
feat(fetch): support X-GM-THRID, X-GM-MSGID, X-GM-LABELS in FetchParser

### DIFF
--- a/lib/src/mime_message.dart
+++ b/lib/src/mime_message.dart
@@ -597,6 +597,10 @@ class MimeMessage extends MimePart {
     this.guid = guid;
   }
 
+  int? xGmThrid; // X-GM-THRID
+  int? xGmMsgid; // X-GM-MSGID
+  List<String>? xGmLabels; // X-GM-LABELS
+
   /// The modifications sequence of this message.
   ///
   /// This is only returned by servers that support the CONDSTORE capability

--- a/lib/src/private/imap/fetch_parser.dart
+++ b/lib/src/private/imap/fetch_parser.dart
@@ -177,6 +177,44 @@ class FetchParser extends ResponseParser<FetchImapResult> {
             _parseBodyFull(message, children[i]);
           }
           break;
+        case 'X-GM-THRID':
+          if (hasNext) {
+            message.xGmThrid = int.tryParse(children[i + 1].value ?? '');
+            i++;
+          }
+          break;
+        case 'X-GM-MSGID':
+          if (hasNext) {
+            message.xGmMsgid = int.tryParse(children[i + 1].value ?? '');
+            i++;
+          }
+          break;
+        case 'X-GM-LABELS':
+          if (hasNext) {
+            final node = children[i + 1];
+            final labels = <String>[];
+
+            final labelChildren = node.children;
+            if (labelChildren != null && labelChildren.isNotEmpty) {
+              for (final c in labelChildren) {
+                final v = c.valueOrDataText;
+                if (v != null && v.isNotEmpty) {
+                  labels.add(v);
+                }
+              }
+            } else {
+              // Fallback if parser provides a single token
+              final v = node.valueOrDataText;
+              if (v != null && v.isNotEmpty) {
+                labels.add(v);
+              }
+            }
+
+            message.xGmLabels = labels;
+            i++;
+          }
+          break;
+
         default:
           final value = child.value;
           if (hasNext &&


### PR DESCRIPTION
📌 Description

This update enhances the IMAP fetch parsing by adding support for Gmail-specific extensions:

X-GM-THRID → Gmail thread ID
X-GM-MSGID → Gmail unique message ID
X-GM-LABELS → Gmail labels associated with the message

These fields are now parsed directly within the FetchParser, making them available alongside standard IMAP attributes.

🚀 Motivation

Gmail provides additional metadata that is not part of the standard IMAP specification but is essential for building a modern email client:

Thread grouping (conversation view)
Reliable message identification across folders
Label-based organization (instead of traditional folders)

Previously, this data was not accessible through the parser, limiting Gmail-specific functionality.

🔧 Changes
Extended FetchParser to recognize and extract:
X-GM-THRID
X-GM-MSGID
X-GM-LABELS
Properly map parsed values into the fetch result structure
Ensure backward compatibility with non-Gmail IMAP servers
✅ Impact
Enables proper threading support (conversation view)
Improves message deduplication and syncing
Allows accurate label synchronization for Gmail accounts
No breaking changes for existing IMAP functionality
⚠️ Notes
These fields are Gmail-specific and may not be present in other IMAP providers
Consumers should handle null/absence cases gracefully
🧪 Testing
Verified against Gmail IMAP (imap.gmail.com)
Tested parsing of:
Messages with multiple labels
Threaded conversations
Standard IMAP responses (non-Gmail) to ensure no regression